### PR TITLE
Mask dates that are 24 hours of now

### DIFF
--- a/packages/jest-serializer-xlsx-populate/index.js
+++ b/packages/jest-serializer-xlsx-populate/index.js
@@ -73,6 +73,8 @@ module.exports = {
             })
           } else if (isTodaysDate(row[j])) {
             row[j] = '<date>'
+          } else if (isNearToday(row[j])) {
+            row[j] = '<date>';
           }
         });
         return row
@@ -91,4 +93,13 @@ function isTodaysDate (value) {
     d = XlsxPopulate.numberToDate(value)
   }
   return _isTodaysDate(d)
+}
+
+function isNearToday (value) {
+  if (typeof value === 'number') {
+    const d = XlsxPopulate.numberToDate(value)
+    const threshold = 1000 * 60 * 60 * 24 // 24 hour threshold
+    return Math.abs(Date.now() - d) < threshold;
+  }
+  return false;
 }


### PR DESCRIPTION
Previously to mask dates we compared todays ISO 8601 date with the date in question. However this does not work when the excel date has been expressed in another timezone. Since neither JS nor excel support timezones the best we can do is use the new heuristic of 24 hours from now.